### PR TITLE
Ref desc2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,9 @@ pllua.o \
 pllua_debug.o \
 plluaapi.o \
 plluaspi.o \
-lua_int64.o
+lua_int64.o \
+rtupdesc.o \
+rtupdescstk.o
 
 PG_CPPFLAGS = $(LUAINC)
 SHLIB_LINK = $(LUALIB)

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,11 @@ DATA = pllua--1.0.sql
 #DATA_built = pllua.sql
 
 REGRESS = plluatest
-OBJS = pllua.o plluaapi.o plluaspi.o
+OBJS = \
+pllua.o \
+pllua_debug.o \
+plluaapi.o \
+plluaspi.o
 PG_CPPFLAGS = $(LUAINC)
 SHLIB_LINK = $(LUALIB)
 
@@ -39,4 +43,5 @@ SHLIB_LINK = $(LUALIB)
 PG_CONFIG ?= pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+#override CPPFLAGS := -I. -I$(srcdir) $(CPPFLAGS) -DPLLUA_DEBUG
 

--- a/expected/plluatest.out
+++ b/expected/plluatest.out
@@ -489,6 +489,25 @@ SELECT echo_mytype((1::int2, 666.777, array[1.0, 2.0]) );
  (1,666.777,"{1.0,2.0}")
 (1 row)
 
+CREATE FUNCTION nested_server_rows () RETURNS SETOF text as
+$$
+for left in server.rows('select generate_series as left from generate_series(3,4) ') do
+for right in server.rows('select generate_series as right from generate_series(5,6) ') do
+	local s = left.left.." "..right.right
+	coroutine.yield(s)
+end
+end
+$$
+language pllua;
+select nested_server_rows();
+ nested_server_rows 
+--------------------
+ 3 5
+ 3 6
+ 4 5
+ 4 6
+(4 rows)
+
 -- body reload
 SELECT hello('PostgreSQL');
        hello        

--- a/pllua.c
+++ b/pllua.c
@@ -71,3 +71,17 @@ Datum pllua_inline_handler(PG_FUNCTION_ARGS) {
 }
 #endif
 
+static const int tuple_info = 0;
+void *p_tuple_info()
+{
+    return &tuple_info;
+}
+
+MemoryContext luaP_getmemctxt(lua_State *L) {
+    MemoryContext mcxt;
+    lua_pushlightuserdata(L, (void *) L);
+    lua_rawget(L, LUA_REGISTRYINDEX);
+    mcxt = (MemoryContext) lua_touserdata(L, -1);
+    lua_pop(L, 1);
+    return mcxt;
+}

--- a/pllua.c
+++ b/pllua.c
@@ -72,19 +72,25 @@ Datum pllua_inline_handler(PG_FUNCTION_ARGS) {
 #endif
 
 
-static const int tuple_info = 0;
-void *p_tuple_info()
-{
-    return &tuple_info;
-}
+void p_lua_mem_cxt(void){}
+void p_lua_master_state(void){}
 
 MemoryContext luaP_getmemctxt(lua_State *L) {
     MemoryContext mcxt;
-    lua_pushlightuserdata(L, (void *) L);
+    lua_pushlightuserdata(L, p_lua_mem_cxt);
     lua_rawget(L, LUA_REGISTRYINDEX);
     mcxt = (MemoryContext) lua_touserdata(L, -1);
     lua_pop(L, 1);
     return mcxt;
+}
+
+lua_State * pllua_getmaster(lua_State *L) {
+    lua_State *master;
+    lua_pushlightuserdata(L, p_lua_master_state);
+    lua_rawget(L, LUA_REGISTRYINDEX);
+    master = (lua_State *) lua_touserdata(L, -1);
+    lua_pop(L, 1);
+    return master;
 }
 
 void luaL_setfuncs(lua_State *L, const luaL_Reg *l, int nup) {
@@ -99,3 +105,6 @@ void luaL_setfuncs(lua_State *L, const luaL_Reg *l, int nup) {
     }
     lua_pop(L, nup);  /* remove upvalues */
 }
+
+
+

--- a/pllua_debug.c
+++ b/pllua_debug.c
@@ -27,13 +27,13 @@
 
 
 static  char *_location;
-void setLINE(const char *location)
+void setLINE(char *location)
 {
     _location = location;
 }
 
 
-const char *getLINE()
+const char *getLINE(void)
 {
     return _location;
 }

--- a/pllua_debug.c
+++ b/pllua_debug.c
@@ -1,0 +1,92 @@
+#include "pllua_debug.h"
+
+/* PostgreSQL */
+#include <postgres.h>
+#include <fmgr.h>
+#include <funcapi.h>
+#include <access/heapam.h>
+#if PG_VERSION_NUM >= 90300
+#include <access/htup_details.h>
+#endif
+#include <catalog/namespace.h>
+#include <catalog/pg_proc.h>
+#include <catalog/pg_type.h>
+#include <commands/trigger.h>
+#include <executor/spi.h>
+#include <nodes/makefuncs.h>
+#include <parser/parse_type.h>
+#include <utils/array.h>
+#include <utils/builtins.h>
+#include <utils/datum.h>
+#include <utils/lsyscache.h>
+#include <utils/memutils.h>
+#include <utils/rel.h>
+#include <utils/syscache.h>
+#include <utils/typcache.h>
+
+
+
+static  char *_location;
+void setLINE(const char *location)
+{
+    _location = location;
+}
+
+
+const char *getLINE()
+{
+    return _location;
+}
+
+
+#define DMP 2
+
+void stackDump(lua_State *L) {
+    int i=lua_gettop(L);
+    ereport(INFO, (errmsg("%s", "----------------  Stack Dump ----------------")));
+    while(  i   ) {
+        int t = lua_type(L, i);
+        switch (t) {
+        case LUA_TSTRING:
+            ereport(INFO, (errmsg("%d:`%s'", i, lua_tostring(L, i))));
+            break;
+        case LUA_TBOOLEAN:
+            ereport(INFO, (errmsg("%d: %s",i,lua_toboolean(L, i) ? "true" : "false")));
+            break;
+        case LUA_TNUMBER:
+            ereport(INFO, (errmsg("%d: %g",  i, lua_tonumber(L, i))));
+            break;
+        case LUA_TTABLE:
+            ereport(INFO, (errmsg("%d: table",  i)));
+            if (DMP==1){
+                /* table is in the stack at index 't' */
+                lua_pushnil(L);  /* first key */
+
+                while (lua_next(L, i) != 0) {
+                    /* uses 'key' (at index -2) and 'value' (at index -1) */
+                    ereport(INFO, (errmsg("===%s - %s\n",
+                                          lua_tostring(L, -2),
+                                          lua_typename(L, lua_type(L, -1)))));
+                    /* removes 'value'; keeps 'key' for next iteration */
+                    lua_pop(L, 1);
+                }
+            }else if (DMP == 2){
+                int cnt = 0;
+                lua_pushnil(L);  /* first key */
+
+                while (lua_next(L, i) != 0) {
+                    ++cnt;
+                    /* removes 'value'; keeps 'key' for next iteration */
+                    lua_pop(L, 1);
+                }
+                ereport(INFO, (errmsg("===length %i: table",  cnt)));
+            }
+            break;
+        default:
+            ereport(INFO, (errmsg("%d: %s", i, lua_typename(L, t))));
+            break;
+        }
+        i--;
+    }
+    ereport(INFO, (errmsg("%s","--------------- Stack Dump Finished ---------------" )));
+}

--- a/pllua_debug.h
+++ b/pllua_debug.h
@@ -6,8 +6,8 @@
 #include <lauxlib.h>
 
 
-void setLINE(const char *location);
-const char * getLINE();
+void setLINE(char *location);
+const char * getLINE(void);
 
 
 #include <stdio.h>
@@ -24,5 +24,6 @@ void stackDump (lua_State *L);
 
 
 #define out(...) ereport(INFO, (errmsg(__VA_ARGS__)))
+#define dolog(...) ereport(LOG, (errmsg(__VA_ARGS__)))
 
 #endif // PLLUA_DEBUG_H

--- a/pllua_debug.h
+++ b/pllua_debug.h
@@ -1,0 +1,28 @@
+#ifndef PLLUA_DEBUG_H
+#define PLLUA_DEBUG_H
+
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
+
+
+void setLINE(const char *location);
+const char * getLINE();
+
+
+#include <stdio.h>
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+#define AT __FILE__ ":" TOSTRING(__LINE__)
+
+void stackDump (lua_State *L);
+
+#define lua_settable(...) setLINE(AT);lua_settable(__VA_ARGS__)
+#define lua_rawseti(...) setLINE(AT);lua_rawseti(__VA_ARGS__)
+#define lua_rawset(...) setLINE(AT);lua_rawset(__VA_ARGS__)
+#define lua_setmetatable(...) setLINE(AT);lua_setmetatable(__VA_ARGS__)
+
+
+#define out(...) ereport(INFO, (errmsg(__VA_ARGS__)))
+
+#endif // PLLUA_DEBUG_H

--- a/plluaapi.c
+++ b/plluaapi.c
@@ -7,6 +7,7 @@
 #include "pllua.h"
 #include "rowstamp.h"
 #include "lua_int64.h"
+#include "rtupdescstk.h"
 
 /*
  * [[ Uses of REGISTRY ]]
@@ -27,6 +28,7 @@
 
 /* extended function info */
 typedef struct luaP_Info {
+  RTupDescStack funcxt;
   int oid;
   int vararg;
   Oid result;
@@ -279,6 +281,7 @@ static void luaP_preptrigger (lua_State *L, TriggerData *tdata) {
   luaP_pushdesctable(L, tdata->tg_relation->rd_att);
   lua_pushinteger(L, (int) tdata->tg_relation->rd_id);
   lua_pushvalue(L, -2); /* attribute table */
+  
   lua_rawset(L, LUA_REGISTRYINDEX); /* cache desc */
   lua_setfield(L, -2, "attributes");
   lua_pushinteger(L, (int) tdata->tg_relation->rd_id);
@@ -291,16 +294,16 @@ static void luaP_preptrigger (lua_State *L, TriggerData *tdata) {
   /* row */
   if (TRIGGER_FIRED_FOR_ROW(tdata->tg_event)) {
     if (TRIGGER_FIRED_BY_UPDATE(tdata->tg_event)) {
-      luaP_pushtuple(L, tdata->tg_relation->rd_att, tdata->tg_newtuple,
-          tdata->tg_relation->rd_id, 0,0);
+      luaP_pushtuple_trg(L, tdata->tg_relation->rd_att, tdata->tg_newtuple,
+          tdata->tg_relation->rd_id, 0);
       lua_setfield(L, -2, "row"); /* new row */
-      luaP_pushtuple(L, tdata->tg_relation->rd_att, tdata->tg_trigtuple,
-          tdata->tg_relation->rd_id, 1,0);
+      luaP_pushtuple_trg(L, tdata->tg_relation->rd_att, tdata->tg_trigtuple,
+          tdata->tg_relation->rd_id, 1);
       lua_setfield(L, -2, "old"); /* old row */
     }
     else { /* insert or delete */
-      luaP_pushtuple(L, tdata->tg_relation->rd_att, tdata->tg_trigtuple,
-          tdata->tg_relation->rd_id, 0,0);
+      luaP_pushtuple_trg(L, tdata->tg_relation->rd_att, tdata->tg_trigtuple,
+          tdata->tg_relation->rd_id, 0);
       lua_setfield(L, -2, "row"); /* old row */
     }
   }
@@ -322,6 +325,7 @@ static Datum luaP_gettriggerresult (lua_State *L) {
 }
 
 static void luaP_cleantrigger (lua_State *L) {
+  rtds_tryclean(rtds_get_current()); //fi->functx;
   lua_pushglobaltable(L);
   lua_pushstring(L, PLLUA_TRIGGERVAR);
   lua_pushnil(L);
@@ -474,6 +478,7 @@ void luaP_close (lua_State *L) {
 
 lua_State *luaP_newstate (int trusted) {
   int status;
+
   MemoryContext mcxt = AllocSetContextCreate(TopMemoryContext,
       "PL/Lua context", ALLOCSET_DEFAULT_MINSIZE, ALLOCSET_DEFAULT_INITSIZE,
       ALLOCSET_DEFAULT_MAXSIZE);
@@ -482,8 +487,12 @@ lua_State *luaP_newstate (int trusted) {
   lua_pushliteral(L, PLLUA_VERSION);
   lua_setglobal(L, "_PLVERSION");
   /* memory context */
-  lua_pushlightuserdata(L, (void *) L);
+  lua_pushlightuserdata(L, p_lua_mem_cxt);
   lua_pushlightuserdata(L, (void *) mcxt);
+  lua_rawset(L, LUA_REGISTRYINDEX);
+
+  lua_pushlightuserdata(L, p_lua_master_state);
+  lua_pushlightuserdata(L, (void *) L);
   lua_rawset(L, LUA_REGISTRYINDEX);
   /* core libs */
   if (trusted) {
@@ -557,11 +566,7 @@ lua_State *luaP_newstate (int trusted) {
   lua_pushglobaltable(L);
   luaP_register(L, luaP_funcs);
   lua_pop(L, 1);
-  //----------------------------------
-  lua_pushlightuserdata(L, p_tuple_info);
-  lua_newtable(L);
-  lua_settable(L, LUA_REGISTRYINDEX);
-  //----------------------------------
+
   /* SPI */
   luaP_registerspi(L);
   lua_setglobal(L, PLLUA_SPIVAR);
@@ -608,6 +613,7 @@ static luaP_Info *luaP_newinfo (lua_State *L, int nargs, int oid,
   int i;
   luaP_Typeinfo *ti;
   fi = lua_newuserdata(L, sizeof(luaP_Info) + nargs * sizeof(Oid));
+  fi->funcxt = NULL;
   fi->oid = oid;
   /* read arg types */
   for (i = 0; i < nargs; i++) {
@@ -804,7 +810,6 @@ void luaP_pushdatum (lua_State *L, Datum dat, Oid type) {
       lua_pushinteger(L, (lua_Integer) DatumGetInt32(dat));
       break;
     case INT8OID:
-	//pushint64 lua_int64.c
         setInt64lua(L,(DatumGetInt64(dat)));
         break;
     case TEXTOID:
@@ -1166,11 +1171,12 @@ static Datum luaP_getresult (lua_State *L, FunctionCallInfo fcinfo,
 
 /* ======= luaP_callhandler ======= */
 
-static void luaP_cleanthread (lua_State *L, lua_State **thread) {
-  lua_pushlightuserdata(L, (void *) *thread);
-  lua_pushnil(L);
-  lua_rawset(L, LUA_REGISTRYINDEX);
-  *thread = NULL;
+static void luaP_cleanthread (lua_State *L, lua_State **thread, luaP_Info *fi) {
+    fi->funcxt = rtds_free_if_not_used(fi->funcxt);
+    lua_pushlightuserdata(L, (void *) *thread);
+    lua_pushnil(L);
+    lua_rawset(L, LUA_REGISTRYINDEX);
+    *thread = NULL;
 }
 
 Datum luaP_validator (lua_State *L, Oid oid) {
@@ -1198,11 +1204,18 @@ Datum luaP_validator (lua_State *L, Oid oid) {
 Datum luaP_callhandler (lua_State *L, FunctionCallInfo fcinfo) {
   Datum retval = 0;
   luaP_Info *fi;
+  RTupDescStack prev;
   bool istrigger;
   if (SPI_connect() != SPI_OK_CONNECT)
     elog(ERROR, "[pllua]: could not connect to SPI manager");
   istrigger = CALLED_AS_TRIGGER(fcinfo);
   fi = luaP_pushfunction(L, (int) fcinfo->flinfo->fn_oid);
+  if (fi->funcxt == NULL){
+      fi->funcxt = rtds_initStack(L);
+  }
+  rtds_inuse(fi->funcxt);
+
+  prev = rtds_set_current(fi->funcxt);
   PG_TRY();
   {
     if ((fi->result == TRIGGEROID && !istrigger)
@@ -1249,11 +1262,13 @@ Datum luaP_callhandler (lua_State *L, FunctionCallInfo fcinfo) {
         }
         lua_xmove(L, fi->L, 1); /* function */
         luaP_pushargs(fi->L, fcinfo, fi);
+
 #if LUA_VERSION_NUM <= 501
         status = lua_resume(fi->L, fcinfo->nargs);
 #else
         status = lua_resume(fi->L, fi->L, fcinfo->nargs);
 #endif
+        rtds_notinuse(fi->funcxt);
         hasresult = !lua_isnoneornil(fi->L, 1);
         if (status == LUA_YIELD && hasresult) {
           rsi->isDone = ExprMultipleResult; /* SRF: next */
@@ -1263,7 +1278,7 @@ Datum luaP_callhandler (lua_State *L, FunctionCallInfo fcinfo) {
           rsi->isDone = ExprEndResult; /* SRF: done */
           fcinfo->isnull = true;
           retval = (Datum) 0;
-          luaP_cleanthread(L, &fi->L);
+          luaP_cleanthread(L, &fi->L, fi);
         }
         else {
 #if defined(PLLUA_DEBUG)
@@ -1276,12 +1291,16 @@ Datum luaP_callhandler (lua_State *L, FunctionCallInfo fcinfo) {
       else {
         luaP_pushargs(L, fcinfo, fi);
         if (lua_pcall(L, fcinfo->nargs, 1, 0)){
+
+            fi->funcxt = rtds_unref(fi->funcxt);
 #if defined(PLLUA_DEBUG)
         luaP_error(L, getLINE());
 #else
         luaP_error(L, "runtime");
 #endif
     }
+        fi->funcxt = rtds_unref(fi->funcxt);
+
         retval = luaP_getresult(L, fcinfo, fi->result);
       }
     }
@@ -1290,9 +1309,10 @@ Datum luaP_callhandler (lua_State *L, FunctionCallInfo fcinfo) {
   PG_CATCH();
   {
     if (L != NULL) {
-      luaP_cleantrigger(L);
+      luaP_cleantrigger(L);//fi->funcxt ref--
+
       if (fi->result_isset && fi->L != NULL) /* clean thread? */
-        luaP_cleanthread(L, &fi->L);
+        luaP_cleanthread(L, &fi->L, fi);
       lua_settop(L, 0); /* clear Lua stack */
     }
     fcinfo->isnull = true;
@@ -1300,28 +1320,40 @@ Datum luaP_callhandler (lua_State *L, FunctionCallInfo fcinfo) {
     PG_RE_THROW();
   }
   PG_END_TRY();
+  rtds_set_current(prev);
   if (SPI_finish() != SPI_OK_FINISH)
     elog(ERROR, "[pllua]: could not disconnect from SPI manager");
   return retval;
 }
 
+#include "rtupdesc.h"
 #if PG_VERSION_NUM >= 90000
 /* ======= luaP_inlinehandler ======= */
 
 Datum luaP_inlinehandler (lua_State *L, const char *source) {
+    RTupDescStack funcxt;
+    RTupDescStack prev;
   if (SPI_connect() != SPI_OK_CONNECT)
     elog(ERROR, "[pllua]: could not connect to SPI manager");
+
+  funcxt = rtds_initStack(L);
+  rtds_inuse(funcxt);
+
+  prev = rtds_set_current(funcxt);
   PG_TRY();
   {
     if (luaL_loadbuffer(L, source, strlen(source), PLLUA_CHUNKNAME))
       luaP_error(L, "compile");
     if (lua_pcall(L, 0, 0, 0)) {
+        funcxt = rtds_unref(funcxt);
+        rtds_set_current(prev);
 #if defined(PLLUA_DEBUG)
         luaP_error(L, getLINE());
 #else
         luaP_error(L, "runtime");
 #endif
     }
+
   }
   PG_CATCH();
   {
@@ -1329,6 +1361,10 @@ Datum luaP_inlinehandler (lua_State *L, const char *source) {
     PG_RE_THROW();
   }
   PG_END_TRY();
+
+  funcxt = rtds_unref(funcxt);
+  rtds_set_current(prev);
+
   if (SPI_finish() != SPI_OK_FINISH)
     elog(ERROR, "[pllua]: could not disconnect from SPI manager");
   PG_RETURN_VOID();

--- a/plluacommon.h
+++ b/plluacommon.h
@@ -1,0 +1,73 @@
+#ifndef PLLUACOMMON_H
+#define PLLUACOMMON_H
+
+/* PostgreSQL */
+#include <postgres.h>
+#include <fmgr.h>
+#include <funcapi.h>
+#include <access/heapam.h>
+#if PG_VERSION_NUM >= 90300
+#include <access/htup_details.h>
+#endif
+#include <catalog/namespace.h>
+#include <catalog/pg_proc.h>
+#include <catalog/pg_type.h>
+#include <commands/trigger.h>
+#include <executor/spi.h>
+#include <nodes/makefuncs.h>
+#include <parser/parse_type.h>
+#include <utils/array.h>
+#include <utils/builtins.h>
+#include <utils/datum.h>
+#include <utils/lsyscache.h>
+#include <utils/memutils.h>
+#include <utils/rel.h>
+#include <utils/syscache.h>
+#include <utils/typcache.h>
+/* Lua */
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
+
+#if LUA_VERSION_NUM <= 501
+#define lua_pushglobaltable(L) lua_pushvalue(L, LUA_GLOBALSINDEX)
+#define lua_setuservalue lua_setfenv
+#define lua_getuservalue lua_getfenv
+#define lua_rawlen lua_objlen
+#define luaP_register(L,l) luaL_register(L, NULL, (l))
+#else
+#define luaP_register(L,l) luaL_setfuncs(L, (l), 0)
+#endif
+
+#if !defined LUA_VERSION_NUM || LUA_VERSION_NUM==501
+/*
+** Adapted from Lua 5.2.0
+*/
+void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup);
+#endif
+
+#define PLLUA_VERSION "PL/Lua 1.0"
+
+#if defined(PLLUA_DEBUG)
+#include "pllua_debug.h"
+#define BEGINLUA int ____stk=lua_gettop(L)
+#define ENDLUA ____stk =lua_gettop(L)-____stk; if(0!=____stk) ereport(INFO, (errmsg("stk %s>%i",AT,____stk)))
+#define ENDLUAV(v) ____stk =(lua_gettop(L)-____stk-v); if(0!=____stk) ereport(INFO, (errmsg("stk %s>%i",AT,____stk)))
+#else
+#define BEGINLUA
+#define ENDLUA
+#define ENDLUAV(v)
+#endif
+
+/* get MemoryContext for state L */
+MemoryContext luaP_getmemctxt (lua_State *L);
+
+lua_State *pllua_getmaster (lua_State *L);
+
+#define MTOLUA(state) {MemoryContext ___mcxt,___m;\
+    ___mcxt = luaP_getmemctxt(state); \
+    ___m  = MemoryContextSwitchTo(___mcxt)
+
+#define MTOPG MemoryContextSwitchTo(___m);}
+
+#endif // PLLUACOMMON_H

--- a/rtupdesc.c
+++ b/rtupdesc.c
@@ -1,0 +1,82 @@
+#include "rtupdesc.h"
+
+static int obj_count = 0;
+
+RTupDesc *rtupdesc_ctor(lua_State *state, TupleDesc tupdesc)
+{
+    void* p;
+    RTupDesc* rtupdesc = 0;
+
+    MTOLUA(state);
+    p = palloc(sizeof(RTupDesc));
+    if (p){
+        rtupdesc = (RTupDesc*)p;
+        rtupdesc->ref_count = 1;
+        rtupdesc->tupdesc = CreateTupleDescCopy(tupdesc);
+        obj_count += 1;
+        rtupdesc->weakNodeStk = rtds_push_current(p);
+    }
+    MTOPG;
+
+    return rtupdesc;
+}
+
+
+RTupDesc *rtupdesc_ref(RTupDesc *rtupdesc)
+{
+    if(rtupdesc)
+        rtupdesc->ref_count += 1;
+    return rtupdesc;
+}
+
+
+RTupDesc *rtupdesc_unref(RTupDesc *rtupdesc)
+{
+    if(rtupdesc){
+        rtupdesc->ref_count -= 1;
+        if (rtupdesc->ref_count == 0){
+            rtupdesc_dtor(rtupdesc);
+            return NULL;
+        }
+    }
+    return rtupdesc;
+}
+
+
+void rtupdesc_freedesc(RTupDesc *rtupdesc)
+{
+    if (rtupdesc && rtupdesc->tupdesc){
+        FreeTupleDesc(rtupdesc->tupdesc);
+        rtupdesc->tupdesc = NULL;
+        obj_count -= 1;
+    }
+}
+
+TupleDesc rtupdesc_gettup(RTupDesc *rtupdesc)
+{
+    return (rtupdesc ? rtupdesc->tupdesc : NULL);
+}
+
+
+void rtupdesc_dtor(RTupDesc *rtupdesc)
+{
+
+    if(rtupdesc){
+        rtds_remove_node(rtupdesc->weakNodeStk);
+
+        if (rtupdesc->tupdesc){
+            FreeTupleDesc(rtupdesc->tupdesc);
+            rtupdesc->tupdesc = NULL;
+            obj_count -= 1;
+        }
+
+        pfree(rtupdesc);
+
+    }
+
+}
+
+int rtupdesc_obj_count(void)
+{
+    return obj_count;
+}

--- a/rtupdesc.h
+++ b/rtupdesc.h
@@ -1,0 +1,29 @@
+#ifndef RTUPDESC_H
+#define RTUPDESC_H
+
+#include "plluacommon.h"
+#include "rtupdescstk.h"
+
+typedef struct _RTupDesc{
+    int ref_count;
+    RTDNodePtr weakNodeStk;
+    TupleDesc tupdesc;
+} RTupDesc;
+
+RTupDesc* rtupdesc_ctor(lua_State * state, TupleDesc tupdesc);
+
+RTupDesc* rtupdesc_ref(RTupDesc* rtupdesc);
+
+RTupDesc* rtupdesc_unref(RTupDesc* rtupdesc);
+
+
+TupleDesc rtupdesc_gettup(RTupDesc* rtupdesc);
+
+void rtupdesc_freedesc(RTupDesc* rtupdesc);
+
+void rtupdesc_dtor(RTupDesc* rtupdesc);
+
+int rtupdesc_obj_count(void);
+
+
+#endif // RTUPDESC_H

--- a/rtupdescstk.c
+++ b/rtupdescstk.c
@@ -1,0 +1,151 @@
+#include "rtupdescstk.h"
+#include "rtupdesc.h"
+
+static void* current_func_cxt = NULL;
+RTupDescStack rtds_set_current(void *s){
+    RTupDescStack prev = current_func_cxt;
+    current_func_cxt = s;
+    return prev;
+}
+
+RTupDescStack rtds_get_current(void){
+    return current_func_cxt;
+}
+
+static void clean(RTupDescStack S){
+    void *top = rtds_pop(S);
+    while (top) {
+        RTupDesc* rtupdesc = (RTupDesc*)top;
+        rtupdesc_freedesc(rtupdesc);
+        rtupdesc->weakNodeStk = NULL;
+        top = rtds_pop(S);
+    }
+}
+
+void rtds_tryclean(RTupDescStack S){
+    if (S == NULL) return;
+    S->ref_count -= 1;
+    if (S->ref_count != 0) return;
+    clean(S);
+}
+
+void *rtds_pop(RTupDescStack S) {
+    void *hold;
+    RTDNodePtr temp;
+    if (rtds_isempty(S)) {
+        return NULL;
+    }
+    hold = S -> top -> data;
+    temp = S -> top;
+    S -> top = S -> top -> next;
+    if (S->top != NULL)
+        S -> top->prev = NULL;
+    pfree(temp);
+    return hold;
+}
+
+
+static RTDNodePtr rtds_push(RTupDescStack S, void *d) {
+    RTDNodePtr np;
+    if (S == NULL) return NULL;
+    MTOLUA(S->L);
+    np = (RTDNodePtr) palloc(sizeof(RTDNode));
+    MTOPG;
+    np->tail = S;
+    np -> data = d;
+    np -> next = S -> top;
+    np -> prev = NULL;
+    if (S->top != NULL)
+        S -> top->prev = np;
+    S -> top = np;
+    return np;
+}
+
+
+int rtds_isempty(RTupDescStack S) {
+    return (S -> top == NULL);
+}
+
+
+RTupDescStack rtds_initStack(lua_State *L) {
+    RTupDescStack sp;
+    L = pllua_getmaster(L);
+    MTOLUA(L);
+    sp = (RTupDescStack) palloc(sizeof(RTupDescStackType));
+    MTOPG;
+    sp->ref_count = 0;
+    sp->L = L;
+    sp->top = NULL;
+    return sp;
+}
+
+
+RTDNodePtr rtds_push_current(void *d)
+{
+    return rtds_push(current_func_cxt,d);
+}
+
+
+RTupDescStack rtds_unref(RTupDescStack S)
+{
+    if (S == NULL) return NULL;
+    rtds_notinuse(S);
+    return rtds_free_if_not_used(S);
+}
+
+
+void rtds_remove_node(RTDNodePtr np)
+{
+    RTupDescStack S;
+    if (np == NULL) return;
+    S = np->tail;
+    if (S->top == np){
+        S->top = np->next;
+        if (S->top){
+            S->top->prev = NULL;
+        }
+    }else{
+        if (np->prev)
+            np->prev->next = np->next;
+        if (np->next)
+            np->next->prev = np->prev;
+    }
+    pfree(np);
+
+}
+
+
+int rtds_get_length(RTupDescStack S)
+{
+    int count = 0;
+    RTDNodePtr node = S->top;
+    while(node){
+        count += 1;
+        node = node->next;
+    }
+    return count;
+}
+
+
+void rtds_inuse(RTupDescStack S)
+{
+    S->ref_count += 1;
+}
+
+
+void rtds_notinuse(RTupDescStack S)
+{
+    S->ref_count -= 1;
+}
+
+
+RTupDescStack rtds_free_if_not_used(RTupDescStack S)
+{
+    if (S == NULL) return NULL;
+    if (S->ref_count == 0){
+        clean(S);
+        pfree(S);
+        return NULL;
+    }
+    return S;
+}

--- a/rtupdescstk.h
+++ b/rtupdescstk.h
@@ -1,0 +1,49 @@
+#ifndef RTUPDESCSTK_H
+#define RTUPDESCSTK_H
+
+#include "plluacommon.h"
+
+#include <stdlib.h>
+struct stackType;
+
+typedef struct RTDnode {
+    void *data;
+    struct RTDnode *next;
+    struct RTDnode *prev;
+    struct stackType *tail;
+} RTDNode, *RTDNodePtr;
+
+typedef struct stackType {
+    int ref_count;
+    lua_State *L;
+    RTDNodePtr top;
+} RTupDescStackType, *RTupDescStack;
+
+RTupDescStack rtds_set_current(void *s);
+RTupDescStack rtds_get_current(void);
+
+int rtds_get_length(RTupDescStack S);
+
+
+RTupDescStack rtds_initStack(lua_State *L);
+
+int rtds_isempty(RTupDescStack S);
+
+
+void *rtds_pop(RTupDescStack S);
+
+void rtds_tryclean(RTupDescStack S);
+
+RTDNodePtr rtds_push_current(void *d);
+void rtds_remove_node(RTDNodePtr np);
+
+void rtds_inuse(RTupDescStack S);
+void rtds_notinuse(RTupDescStack S);
+
+RTupDescStack rtds_unref(RTupDescStack S);
+RTupDescStack rtds_free_if_not_used(RTupDescStack S);
+
+
+
+
+#endif // RTUPDESCSTK_H

--- a/sql/plluatest.sql
+++ b/sql/plluatest.sql
@@ -288,6 +288,18 @@ CREATE TYPE mytype AS (id int2, val mynum, val_list numeric[]);
 CREATE FUNCTION echo_mytype(arg mytype) RETURNS mytype AS $$ return arg $$ LANGUAGE pllua;
 SELECT echo_mytype((1::int2, 666.777, array[1.0, 2.0]) );
 
+CREATE FUNCTION nested_server_rows () RETURNS SETOF text as
+$$
+for left in server.rows('select generate_series as left from generate_series(3,4) ') do
+for right in server.rows('select generate_series as right from generate_series(5,6) ') do
+	local s = left.left.." "..right.right
+	coroutine.yield(s)
+end
+end
+$$
+language pllua;
+select nested_server_rows();
+
 -- body reload
 SELECT hello('PostgreSQL');
 CREATE OR REPLACE FUNCTION hello(name text)


### PR DESCRIPTION
I was trying to get rid of usage numbers as keys for LUA_REGISTRYINDEX, but it's like rewrite tons of code (http://www.lua.org/pil/27.3.2.html). These changes remove usage invalidoid for storing tuple info for all queries. Triggers works in an old way. Fix #1

Added useful helper functions for debugging lua/C code (just enable PLLUA_DEBUG)  that change out info(showed source code last used lua c api function). 

There are lots of changes, and I'm not sure if everything is clear from the commit comment. Any ideas, suggestions, reviews are welcome.
