### PR TITLE
remake report messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 before_install:
-  - sudo apt-get install $LUA
-  - sudo apt-get install $LUA_DEV
   - psql --version
   - sudo /etc/init.d/postgresql stop
   - sudo apt-get -y --purge remove postgresql libpq-dev libpq5 postgresql-client-common postgresql-common
@@ -15,6 +13,8 @@ before_install:
   - sudo echo "host    all         all         127.0.0.1/32          trust" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
   - sudo echo "host    all         all         ::1/128               trust" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
   - sudo /etc/init.d/postgresql restart
+  - sudo apt-get install $LUA
+  - sudo apt-get install $LUA_DEV
 
 before_script:
   - createuser -U postgres -s travis

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ REGRESS = \
 plluatest \
 biginttest \
 pgfunctest \
-subtransaction
+subtransaction \
+error_info
 
 OBJS = \
 pllua.o \
@@ -46,7 +47,8 @@ lua_int64.o \
 rtupdesc.o \
 rtupdescstk.o \
 pllua_pgfunc.o \
-pllua_subxact.o
+pllua_subxact.o \
+pllua_errors.o
 
 PG_CPPFLAGS = -I$(LUA_INCDIR) #-DPLLUA_DEBUG
 SHLIB_LINK = $(LUALIB)

--- a/expected/error_info.out
+++ b/expected/error_info.out
@@ -1,0 +1,119 @@
+do $$ 
+local testfunc = function () error("my error") end
+local f = function()
+	local status, err = pcall(testfunc)
+	if (err) then
+		error(err)
+	end
+end
+f()
+$$language pllua;
+ERROR:  my error
+CONTEXT:  
+stack traceback(trusted):
+	[C]: in function 'error'
+	[string "anonymous"]:6: in function 'f'
+	[string "anonymous"]:9: in main chunk
+create or replace function pg_temp.function_with_error() returns integer as $$
+	local testfunc = function () error("my error") end
+	local f = function()
+		local status, err = pcall(testfunc)
+		if (err) then
+			error(err)
+		end
+	end
+	f()
+$$language plluau;
+create or replace function pg_temp.second_function() returns void as $$
+	for k in server.rows('select pg_temp.function_with_error()') do
+	end
+$$language plluau;
+do $$ 
+	server.execute('select pg_temp.second_function()') 
+$$language pllua;
+ERROR:  my error
+CONTEXT:  
+stack traceback(untrusted):
+	[C]: in function 'error'
+	[string "function_with_error"]:6: in function 'f'
+	[string "function_with_error"]:9: in function <[string "function_with_error"]:1>
+	[C]: in function '(for generator)'
+	[string "second_function"]:2: in function <[string "second_function"]:1>
+SQL statement "select pg_temp.second_function()"
+SQL statement "select pg_temp.second_function()"
+stack traceback(trusted):
+	[C]: in function 'execute'
+	[string "anonymous"]:2: in main chunk
+do $$
+local status, err = subtransaction(function() assert(1==2) end)
+if (err) then
+    error(err)
+end
+$$language pllua;
+ERROR:  assertion failed!
+CONTEXT:  
+stack traceback(trusted):
+	[C]: in function 'error'
+	[string "anonymous"]:4: in main chunk
+do $$
+info({message="info message", hint="info hint", detail="info detail"})
+$$language pllua;
+INFO:  info message
+DETAIL:  info detail
+HINT:  info hint
+do $$
+info("info message")
+$$language pllua;
+INFO:  info message
+do $$
+warning({message="warning message", hint="warning hint", detail="warning detail"})
+$$language pllua;
+WARNING:  warning message
+DETAIL:  warning detail
+HINT:  warning hint
+do $$
+warning("warning message")
+$$language pllua;
+WARNING:  warning message
+do $$
+error({message="error message", hint="error hint", detail="error detail"})
+$$language pllua;
+ERROR:  error message
+DETAIL:  error detail
+HINT:  error hint
+CONTEXT:  
+stack traceback(trusted):
+	[C]: in function 'error'
+	[string "anonymous"]:2: in main chunk
+do $$
+error("error message")
+$$language pllua;
+ERROR:  error message
+CONTEXT:  
+stack traceback(trusted):
+	[C]: in function 'error'
+	[string "anonymous"]:2: in main chunk
+do $$
+info()
+$$language pllua;
+ERROR:  [string "anonymous"]:2: bad argument #1 to 'info' (string expected, got no value)
+CONTEXT:  
+stack traceback(trusted):
+	[C]: in function 'info'
+	[string "anonymous"]:2: in main chunk
+do $$
+warning()
+$$language pllua;
+ERROR:  [string "anonymous"]:2: bad argument #1 to 'warning' (string expected, got no value)
+CONTEXT:  
+stack traceback(trusted):
+	[C]: in function 'warning'
+	[string "anonymous"]:2: in main chunk
+do $$
+error()
+$$language pllua;
+ERROR:  [string "anonymous"]:2: no exception data
+CONTEXT:  
+stack traceback(trusted):
+	[C]: in function 'error'
+	[string "anonymous"]:2: in main chunk

--- a/expected/subtransaction.out
+++ b/expected/subtransaction.out
@@ -31,7 +31,21 @@ $$ LANGUAGE pllua;
 select pg_temp.sub_test();
  sub_test 
 ----------
- nil
+ false
  true
 (2 rows)
 
+do $$
+local status, result = subtransaction(function() 
+server.execute('select 1,'); -- < special SQL syntax error
+end);
+print (status, result)
+status, result = pcall(function() 
+server.execute('select 1,'); -- < special SQL syntax error
+end);
+print (status, result)
+print ('done')
+$$ language pllua;
+INFO:  false	syntax error at end of input
+INFO:  false	syntax error at end of input
+INFO:  done

--- a/lua_int64.c
+++ b/lua_int64.c
@@ -36,6 +36,8 @@ source:https://github.com/idning/lua-int64.git
 #endif
 
 #include "pllua.h"
+#include "pllua_errors.h"
+
 static const char int64_type_name[] = "int64";
 
 static int64_t check_int64(lua_State* L, int idx) {\

--- a/pllua_errors.c
+++ b/pllua_errors.c
@@ -1,0 +1,298 @@
+#include "pllua_errors.h"
+#include "plluacommon.h"
+
+extern LVMInfo lvm_info[2];
+
+static const char error_type_name[] = "pllua_error";
+
+int luaB_assert (lua_State *L) {
+  luaL_checkany(L, 1);
+  if (!lua_toboolean(L, 1))
+    return luaL_error(L, "%s", luaL_optstring(L, 2, "assertion failed!"));
+  return lua_gettop(L);
+}
+
+int luaB_error (lua_State *L) {
+    int level = luaL_optint(L, 2, 1);
+    lua_settop(L, 1);
+    if (lua_isnoneornil(L, 1)){
+        if (lua_isnil(L, 1)){
+            lua_pop(L, 1);
+        }
+        if (level >0){
+            luaL_where(L, level);
+            lua_pushstring(L, "no exception data");
+            lua_concat(L, 2);
+        }else{
+            lua_pushstring(L, "no exception data");
+        }
+    }else
+//    if (lua_isstring(L, 1) && level > 0) {  /* add extra information? */
+//        luaL_where(L, level);
+//        lua_pushvalue(L, 1);
+//        lua_concat(L, 2);
+//    } else
+    if (lua_istable(L,1)){
+        set_error_mt(L);
+    }
+    return lua_error(L);
+}
+
+
+int luaL_error_skip_where (lua_State *L, const char *fmt, ...) {
+  va_list argp;
+  va_start(argp, fmt);
+  /*luaL_where(L, 1);*/
+  lua_pushvfstring(L, fmt, argp);
+  va_end(argp);
+  /*lua_concat(L, 2);*/
+  return lua_error(L);
+}
+
+static int error_tostring(lua_State *L)
+{
+    lua_pushstring(L, "message");
+    lua_rawget(L, -2);
+    return 1;
+}
+
+static luaL_Reg regs[] =
+{
+    {"__tostring", error_tostring},
+    { NULL, NULL }
+};
+
+void register_error_mt(lua_State *L)
+{
+    lua_newtable(L);
+    lua_pushlightuserdata(L, (void *) error_type_name);
+    lua_pushvalue(L, -2);
+    lua_rawset(L, LUA_REGISTRYINDEX);
+
+    luaP_register(L, regs);
+    lua_pop(L, 1);
+}
+
+void set_error_mt(lua_State *L)
+{
+    luaP_getfield(L, error_type_name);
+    lua_setmetatable(L, -2);
+}
+
+void push_spi_error(lua_State *L, MemoryContext oldcontext)
+{
+    ErrorData  *edata;
+
+    /* Save error info */
+    MemoryContextSwitchTo(oldcontext);
+    edata = CopyErrorData();
+    FlushErrorState();
+    lua_newtable(L);
+    if (edata->message){
+        lua_pushstring(L, edata->message); //"no exception data"
+        lua_setfield(L, -2,  "message");
+    } else {
+        lua_pushstring(L, "no exception data");
+        lua_setfield(L, -2,  "message");
+    }
+
+    if (edata->detail){
+        lua_pushstring(L, edata->detail);
+        lua_setfield(L, -2,  "detail");
+    }
+    if (edata->context){
+        lua_pushstring(L, edata->context);
+        lua_setfield(L, -2,  "context");
+    }
+    if (edata->hint){
+        lua_pushstring(L, edata->hint);
+        lua_setfield(L, -2,  "hint");
+    }
+    if (edata->sqlerrcode){
+        lua_pushinteger(L, edata->sqlerrcode);
+        lua_setfield(L, -2,  "sqlerrcode");
+    }
+    set_error_mt(L);
+
+    FreeErrorData(edata);
+}
+
+
+static void pllua_parse_error(lua_State *L, ErrorData *edata){
+    lua_pushnil(L);
+    while (lua_next(L, -2) != 0) {
+        if (lua_type(L, -2) == LUA_TSTRING){
+            const char *key = lua_tostring(L, -2);
+            if (lua_type(L, -1) == LUA_TSTRING){
+                if (strcmp(key, "message") == 0){
+                    edata->message = pstrdup( lua_tostring(L, -1) );
+                } else if (strcmp(key, "detail") == 0){
+                    edata->detail = pstrdup( lua_tostring(L, -1) );
+                }  else if (strcmp(key, "hint") == 0){
+                    edata->hint = pstrdup( lua_tostring(L, -1) );
+                } else if (strcmp(key, "context") == 0){
+                    edata->context = pstrdup( lua_tostring(L, -1) );
+                }
+
+            }else if (lua_type(L, -1) == LUA_TNUMBER){
+                if (strcmp(key, "sqlerrcode") == 0){
+                    edata->sqlerrcode = (int)( lua_tonumber(L, -1) );
+                }
+            }
+        }
+        lua_pop(L, 1);
+    }
+}
+
+void luatable_topgerror(lua_State *L)
+{
+    luatable_report(L, ERROR);
+}
+
+void luatable_report(lua_State *L, int elevel)
+{
+    ErrorData	edata;
+
+    char	   *query = NULL;
+    int			position = 0;
+
+    edata.message = NULL;
+    edata.sqlerrcode = 0;
+    edata.detail = NULL;
+    edata.hint = NULL;
+    edata.context = NULL;
+
+    pllua_parse_error(L, &edata);
+    lua_pop(L, lua_gettop(L));
+
+    elevel = Min(elevel, ERROR);
+
+    ereport(elevel,
+            (errcode(edata.sqlerrcode ? edata.sqlerrcode : ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
+             errmsg_internal("%s", edata.message ? edata.message : "no exception data"),
+             (edata.detail) ? errdetail_internal("%s", edata.detail) : 0,
+             (edata.context) ? errcontext("%s", edata.context) : 0,
+             (edata.hint) ? errhint("%s", edata.hint) : 0,
+             (query) ? internalerrquery(query) : 0,
+             (position) ? internalerrposition(position) : 0));
+}
+
+
+
+/* this is a copy from lua source to call debug.traceback without access it from metatables */
+#define LEVELS1	12	/* size of the first part of the stack */
+#define LEVELS2	10	/* size of the second part of the stack */
+
+static lua_State *getthread (lua_State *L, int *arg) {
+    if (lua_isthread(L, 1)) {
+        *arg = 1;
+        return lua_tothread(L, 1);
+    }
+    else {
+        *arg = 0;
+        return L;
+    }
+}
+
+static int db_errorfb (lua_State *L) {
+    int level;
+    int firstpart = 1;  /* still before eventual `...' */
+    int arg;
+    lua_State *L1 = getthread(L, &arg);
+    lua_Debug ar;
+    luaL_Buffer b;
+    if (lua_isnumber(L, arg+2)) {
+        level = (int)lua_tointeger(L, arg+2);
+        lua_pop(L, 1);
+    }
+    else
+        level = (L == L1) ? 1 : 0;  /* level 0 may be this own function */
+    if (lua_gettop(L) == arg)
+        lua_pushliteral(L, "");
+    else if (!lua_isstring(L, arg+1)) return 1;  /* message is not a string */
+    else lua_pushliteral(L, "\n");
+
+    luaL_buffinit(L, &b);
+    luaL_addstring(&b, "stack traceback(");
+    luaL_addstring(&b, lvm_info[pllua_getmaster_index(L)].name);
+    luaL_addstring(&b, "):");
+    luaL_pushresult(&b);
+    //lua_pushliteral(L, "stack traceback:");
+    while (lua_getstack(L1, level++, &ar)) {
+        if (level > LEVELS1 && firstpart) {
+            /* no more than `LEVELS2' more levels? */
+            if (!lua_getstack(L1, level+LEVELS2, &ar))
+                level--;  /* keep going */
+            else {
+                lua_pushliteral(L, "\n\t...");  /* too many levels */
+                while (lua_getstack(L1, level+LEVELS2, &ar))  /* find last levels */
+                    level++;
+            }
+            firstpart = 0;
+            continue;
+        }
+        lua_pushliteral(L, "\n\t");
+        lua_getinfo(L1, "Snl", &ar);
+        lua_pushfstring(L, "%s:", ar.short_src);
+        if (ar.currentline > 0)
+            lua_pushfstring(L, "%d:", ar.currentline);
+        if (*ar.namewhat != '\0')  /* is there a name? */
+            lua_pushfstring(L, " in function " LUA_QS, ar.name);
+        else {
+            if (*ar.what == 'm')  /* main? */
+                lua_pushfstring(L, " in main chunk");
+            else if (*ar.what == 'C' || *ar.what == 't')
+                lua_pushliteral(L, " ?");  /* C function or tail call */
+            else
+                lua_pushfstring(L, " in function <%s:%d>",
+                                ar.short_src, ar.linedefined);
+        }
+        lua_concat(L, lua_gettop(L) - arg);
+    }
+    lua_concat(L, lua_gettop(L) - arg);
+    return 1;
+}
+
+int traceback (lua_State *L) {
+    int stateIndex = pllua_getmaster_index(L);
+    if (lvm_info[stateIndex].hasTraceback)
+        return 1;
+
+    if (lua_isstring(L, 1)){ /* 'message' not a string? */
+        lua_newtable(L);
+
+        lua_pushcfunction(L, db_errorfb);
+        lua_pushstring(L,""); /* empty concat string for context */
+        lua_pushinteger(L, 2);  /* skip this function and traceback */
+        lua_call(L, 2, 1);  /* call debug.traceback */
+        lvm_info[stateIndex].hasTraceback = true;
+        lua_setfield(L, -2,  "context");
+        lua_swap(L); /*text <-> table*/
+        lua_setfield(L, -2,  "message");
+        set_error_mt(L);
+        return 1;
+
+    }else if (lua_istable(L,1)){
+
+        lua_pushstring(L,"context");
+        lua_rawget(L, -2);
+        if (!lua_isstring(L, -1)){
+            lua_pop(L,1);
+            lua_pushstring(L,""); /* empty concat string for context */
+        }
+
+        lua_pushcfunction(L, db_errorfb);
+        lua_swap(L);
+
+        lua_pushinteger(L, 2);  /* skip this function and traceback */
+        lua_call(L, 2, 1);  /* call debug.traceback */
+        lvm_info[stateIndex].hasTraceback = true;
+
+        lua_setfield(L, -2,  "context");
+
+        return 1;
+    }
+
+    return 1;  /* keep it intact */
+}
+

--- a/pllua_errors.h
+++ b/pllua_errors.h
@@ -1,0 +1,70 @@
+#ifndef PLLUA_ERRORS_H
+#define PLLUA_ERRORS_H
+
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
+
+#include <postgres.h>
+
+#define PLLUA_PG_CATCH_RETHROW(source_code)  do\
+{\
+    MemoryContext ____oldContext = CurrentMemoryContext;\
+    PG_TRY();\
+    {\
+        source_code\
+    }\
+    PG_CATCH();\
+    {\
+        lua_pop(L, lua_gettop(L));\
+        push_spi_error(L, ____oldContext);\
+        return lua_error(L);\
+    }PG_END_TRY();\
+}while(0)
+
+#if defined(PLLUA_DEBUG)
+#define luapg_error(L, tag) do{\
+    if (lua_type(L, -1) == LUA_TSTRING){ \
+        const char *err = pstrdup( lua_tostring((L), -1)); \
+        lua_pop(L, lua_gettop(L));\
+        ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION), \
+             errmsg("[pllua]: error: %s", tag), \
+             errdetail("%s", err)));\
+    }else {\
+        luatable_topgerror(L);\
+    }\
+    }while(0)
+#else
+#define luapg_error(L, tag)do{\
+  if (lua_type(L, -1) == LUA_TSTRING){ \
+    const char *err = pstrdup( lua_tostring((L), -1)); \
+    lua_pop(L, lua_gettop(L));\
+    ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION), \
+      errmsg("[pllua]: " tag " error"),\
+      errdetail("%s", err)));\
+  }else {\
+        luatable_topgerror(L);\
+  }\
+}while(0)
+#endif
+
+/*shows error as "error text" instead of  "[string "anonymous"]:2: error text*/
+#define luaL_error luaL_error_skip_where
+
+int luaB_assert (lua_State *L);
+int luaB_error (lua_State *L);
+
+
+int luaL_error_skip_where (lua_State *L, const char *fmt, ...);
+
+void register_error_mt(lua_State * L);
+void set_error_mt(lua_State * L);
+
+void push_spi_error(lua_State *L, MemoryContext oldcontext);
+void luatable_topgerror(lua_State *L);
+void luatable_report(lua_State *L, int elevel);
+
+
+int traceback (lua_State *L) ;
+
+#endif // PLLUA_ERRORS_H

--- a/pllua_pgfunc.c
+++ b/pllua_pgfunc.c
@@ -7,6 +7,8 @@
 #include <catalog/pg_language.h>
 #include <lib/stringinfo.h>
 
+#include "pllua_errors.h"
+
 static const char pg_func_type_name[] = "pg_func";
 
 static Oid find_lang_oids(const char* lang){
@@ -202,9 +204,7 @@ static lua_CFunction pg_callable_funcs[] =
     NULL
 };
 
-#define luaP_getfield(L, s) \
-    lua_pushlightuserdata((L), (void *)(s)); \
-    lua_rawget((L), LUA_REGISTRYINDEX)
+
 
 int get_pgfunc(lua_State *L)
 {

--- a/pllua_subxact.h
+++ b/pllua_subxact.h
@@ -13,5 +13,7 @@
 #include <postgres.h>
 
 int use_subtransaction(lua_State * L);
+int subt_luaB_pcall (lua_State *L);
+int subt_luaB_xpcall (lua_State *L);
 
 #endif // PLLUA_SUBXACT_H

--- a/plluacommon.h
+++ b/plluacommon.h
@@ -59,19 +59,7 @@ void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup);
 #define ENDLUA
 #define ENDLUAV(v)
 #endif
-#define PLLUA_PG_CATCH_RETHROW(source_code)  do\
-{\
-    MemoryContext ____oldContext = CurrentMemoryContext;\
-    PG_TRY();\
-    {\
-        source_code\
-    }\
-    PG_CATCH();\
-    {\
-        push_spi_error(L, ____oldContext);\
-        lua_error(L);\
-    }PG_END_TRY();\
-}while(0)
+
 
 #define lua_push_oidstring(L, oid) do\
 {\
@@ -83,13 +71,22 @@ void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup);
     luaL_pushresult(&b);\
 }while(0)
 
-void push_spi_error(lua_State *L, MemoryContext oldcontext);
+typedef struct {
+    const char* name;
+    bool hasTraceback;
+} LVMInfo;
+
 /* get MemoryContext for state L */
 MemoryContext luaP_getmemctxt (lua_State *L);
 
 lua_State *pllua_getmaster (lua_State *L);
+int pllua_getmaster_index(lua_State *L);
 
 #define lua_swap(L) lua_insert(L, -2)
+
+#define luaP_getfield(L, s) \
+    lua_pushlightuserdata((L), (void *)(s)); \
+    lua_rawget((L), LUA_REGISTRYINDEX)
 
 #define MTOLUA(state) {MemoryContext ___mcxt,___m;\
     ___mcxt = luaP_getmemctxt(state); \

--- a/plluaspi.c
+++ b/plluaspi.c
@@ -7,6 +7,8 @@
 
 #include "pllua.h"
 #include "pllua_xact_cleanup.h"
+#include "pllua_errors.h"
+
 #ifndef SPI_prepare_cursor
 #define SPI_prepare_cursor(cmd, nargs, argtypes, copts) \
   SPI_prepare(cmd, nargs, argtypes)
@@ -207,7 +209,11 @@ static int luaP_rowsaux (lua_State *L) {
 
     if (c->tupleQueue == NULL){
 
-        SPI_cursor_fetch(c->cursor, 1, FETCH_CSR_Q);
+
+    PLLUA_PG_CATCH_RETHROW(
+      SPI_cursor_fetch(c->cursor, 1, FETCH_CSR_Q);
+		);
+
         if (SPI_processed == 0){
             SPI_freetuptable(SPI_tuptable);
             c->rtupdesc = rtupdesc_unref(c->rtupdesc);

--- a/rtupdescstk.h
+++ b/rtupdescstk.h
@@ -24,6 +24,7 @@ typedef struct stackType {
     lua_State *L;
     RTDNodePtr top;
     void *resptr;
+    struct stackType **cleanup_ptr; /*func ptr to this struct*/
 } RTupDescStackType, *RTupDescStack;
 
 RTupDescStack rtds_set_current(void *s);
@@ -33,6 +34,7 @@ int rtds_get_length(RTupDescStack S);
 
 
 RTupDescStack rtds_initStack(lua_State *L);
+RTupDescStack rtds_initStack_weak(lua_State *L, RTupDescStack *wp);
 
 int rtds_isempty(RTupDescStack S);
 

--- a/sql/error_info.sql
+++ b/sql/error_info.sql
@@ -1,0 +1,74 @@
+do $$ 
+local testfunc = function () error("my error") end
+local f = function()
+	local status, err = pcall(testfunc)
+	if (err) then
+		error(err)
+	end
+end
+f()
+$$language pllua;
+
+create or replace function pg_temp.function_with_error() returns integer as $$
+	local testfunc = function () error("my error") end
+	local f = function()
+		local status, err = pcall(testfunc)
+		if (err) then
+			error(err)
+		end
+	end
+	f()
+$$language plluau;
+
+create or replace function pg_temp.second_function() returns void as $$
+	for k in server.rows('select pg_temp.function_with_error()') do
+	end
+$$language plluau;
+
+do $$ 
+	server.execute('select pg_temp.second_function()') 
+$$language pllua;
+
+do $$
+local status, err = subtransaction(function() assert(1==2) end)
+if (err) then
+    error(err)
+end
+$$language pllua;
+
+do $$
+info({message="info message", hint="info hint", detail="info detail"})
+$$language pllua;
+
+do $$
+info("info message")
+$$language pllua;
+
+do $$
+warning({message="warning message", hint="warning hint", detail="warning detail"})
+$$language pllua;
+
+do $$
+warning("warning message")
+$$language pllua;
+
+do $$
+error({message="error message", hint="error hint", detail="error detail"})
+$$language pllua;
+
+do $$
+error("error message")
+$$language pllua;
+
+do $$
+info()
+$$language pllua;
+
+do $$
+warning()
+$$language pllua;
+
+do $$
+error()
+$$language pllua;
+

--- a/sql/subtransaction.sql
+++ b/sql/subtransaction.sql
@@ -29,3 +29,14 @@ RETURNS SETOF text AS $$
   coroutine.yield(tostring(status))
 $$ LANGUAGE pllua;
 select pg_temp.sub_test();
+do $$
+local status, result = subtransaction(function() 
+server.execute('select 1,'); -- < special SQL syntax error
+end);
+print (status, result)
+status, result = pcall(function() 
+server.execute('select 1,'); -- < special SQL syntax error
+end);
+print (status, result)
+print ('done')
+$$ language pllua;


### PR DESCRIPTION
- fix #12 
- added traceback for trusted and untrusted pllua
- changed typtype char constants to macro
- added error test
- pcall and xpcall execute in subtransaction,
  subtransaction and pcall now are synonyms(error messages may be different)
- changed subtransaction test
- error, message, log, warning may use strings as well as objects like {message='', detail='', hint=''}
- luaL_error now skips "where" info, changed for use macro, which is luaL_error_skip_where to
  remove unnecessary(lua still uses original luaL_error )
- changed resource ptr for functions to weak
- chunk names changed to function names
- now errors may look like this:

``` LUA
do $$
error({message="error message", hint="error hint", detail="error detail"})
$$language pllua;
ERROR:  error message
DETAIL:  error detail
HINT:  error hint
CONTEXT:  
stack traceback(trusted):
    [C]: in function 'error'
    [string "anonymous"]:2: in main chunk
```
