### PR TITLE
remake pgfunc to accept any language functions

### DIFF
--- a/expected/pgfunctest.out
+++ b/expected/pgfunctest.out
@@ -43,3 +43,33 @@ select pg_temp.pgfunc_test();
  42
 (4 rows)
 
+do $$
+print(pgfunc('quote_nullable(text)')(nil))
+$$ language pllua;
+INFO:  NULL
+create or replace function pg_temp.throw_error(text) returns void as $$
+begin
+raise exception '%', $1;
+end
+$$ language plpgsql;
+do $$
+pgfunc('pg_temp.throw_error(text)',{only_internal=false})("exception test")
+$$ language pllua;
+ERROR:  exception test
+CONTEXT:  
+stack traceback(trusted):
+	[C]: ?
+	[string "anonymous"]:2: in main chunk
+do $$
+local f = pgfunc('pg_temp.throw_error(text)',{only_internal=false})
+print(pcall(f, "exception test"))
+$$ language pllua;
+INFO:  false	exception test
+create or replace function pg_temp.no_throw() returns jsonb as $$
+select '{"a":5, "b":10}'::jsonb
+$$ language sql;
+do $$
+local f = pgfunc('pg_temp.no_throw()',{only_internal=false, throwable=false})
+print(f())
+$$ language pllua;
+INFO:  {"a": 5, "b": 10}

--- a/sql/pgfunctest.sql
+++ b/sql/pgfunctest.sql
@@ -36,3 +36,31 @@ RETURNS SETOF text AS $$
   coroutine.yield(i_void.getAnswer())
 $$ LANGUAGE pllua;
 select pg_temp.pgfunc_test();
+
+do $$
+print(pgfunc('quote_nullable(text)')(nil))
+$$ language pllua;
+
+create or replace function pg_temp.throw_error(text) returns void as $$
+begin
+raise exception '%', $1;
+end
+$$ language plpgsql;
+
+do $$
+pgfunc('pg_temp.throw_error(text)',{only_internal=false})("exception test")
+$$ language pllua;
+
+do $$
+local f = pgfunc('pg_temp.throw_error(text)',{only_internal=false})
+print(pcall(f, "exception test"))
+$$ language pllua;
+
+create or replace function pg_temp.no_throw() returns jsonb as $$
+select '{"a":5, "b":10}'::jsonb
+$$ language sql;
+
+do $$
+local f = pgfunc('pg_temp.no_throw()',{only_internal=false, throwable=false})
+print(f())
+$$ language pllua;


### PR DESCRIPTION
- now possible to call plpgsql(and other) functions
- added tempmemory context for function calls
- added new tests
- added options as a second parameter for pgfunc

if pgfunc uses is not internal than second arg should be used:
secod arg is table with options {only_intermal = false, throwable = false} 
if function is not internal, than when throwable == true then pg_try pg_catch are used inside 
