### PR TITLE
pgfunc in/out functions support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ env:
     - PGVERSION=9.4 LUA=lua5.1 LUA_DEV=liblua5.1-dev LUA_INCDIR=/usr/include/lua5.1 LUALIB=-llua5.1
     - PGVERSION=9.4 LUA=lua5.3 LUA_DEV=liblua5.3-dev LUA_INCDIR=/usr/include/lua5.3 LUALIB=-llua5.3
     - PGVERSION=9.4 LUA=luajit LUA_DEV=libluajit-5.1-dev LUA_INCDIR=/usr/include/luajit-2.0 LUALIB=-lluajit-5.1
+    - PGVERSION=9.5 LUA=lua5.1 LUA_DEV=liblua5.1-dev LUA_INCDIR=/usr/include/lua5.1 LUALIB=-llua5.1
+    - PGVERSION=9.5 LUA=lua5.3 LUA_DEV=liblua5.3-dev LUA_INCDIR=/usr/include/lua5.3 LUALIB=-llua5.3
+    - PGVERSION=9.5 LUA=luajit LUA_DEV=libluajit-5.1-dev LUA_INCDIR=/usr/include/luajit-2.0 LUALIB=-lluajit-5.1
 
 
 language: c

--- a/expected/pgfunctest.out
+++ b/expected/pgfunctest.out
@@ -73,3 +73,35 @@ local f = pgfunc('pg_temp.no_throw()',{only_internal=false, throwable=false})
 print(f())
 $$ language pllua;
 INFO:  {"a": 5, "b": 10}
+CREATE or replace FUNCTION pg_temp.arg_count(a1 integer,a2 integer,a3 integer,a4 integer,a5 integer
+,a6 integer,a7 integer,a8 integer,a9 integer,a10 integer
+,a11 integer,a12 integer,a13 integer,a14 integer,a15 integer ) returns integer AS
+$$
+begin
+return a1+a2+a3+a4+a5+a6+a7+a8+a9+a10+a11+a12+a13+a14+a15;
+end
+$$
+LANGUAGE plpgsql;
+do $$
+local f = pgfunc([[pg_temp.arg_count(integer, integer, integer, integer, integer,
+ integer, integer, integer, integer, integer, 
+ integer, integer, integer, integer, integer ) ]],{only_internal=false});
+print(f(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15))
+$$ language pllua;
+INFO:  120
+CREATE or replace FUNCTION pg_temp.inoutf(a integer, INOUT b text, INOUT c text)  AS
+$$
+begin
+c = a||'c:'||c;
+b = 'b:'||b;
+end
+$$
+LANGUAGE plpgsql;
+do $$
+local f = pgfunc('pg_temp.inoutf(integer,text,text)',{only_internal=false});
+local r = f(5, 'ABC', 'd')
+print(r.b)
+print(r.c)
+$$ language pllua
+INFO:  b:ABC
+INFO:  5c:d

--- a/expected/plluatest.out
+++ b/expected/plluatest.out
@@ -534,6 +534,22 @@ select quote_nullable(pg_temp.srf());
  '1'
 (1 row)
 
+CREATE or replace FUNCTION pg_temp.inoutf(a integer, INOUT b text, INOUT c text)  AS
+$$
+begin
+c = a||'c:'||c;
+b = 'b:'||b;
+end
+$$
+LANGUAGE plpgsql;
+do $$
+local a = server.execute("SELECT pg_temp.inoutf(5, 'ABC', 'd') as val ");
+local r = a[1].val
+print(r.b)
+print(r.c)
+$$ language pllua;
+INFO:  b:ABC
+INFO:  5c:d
 -- body reload
 SELECT hello('PostgreSQL');
        hello        

--- a/pllua.h
+++ b/pllua.h
@@ -44,6 +44,7 @@ Oid luaP_gettypeoid (const char *type_name);
 void luaP_pushdesctable(lua_State *L, TupleDesc desc);
 void luaP_registerspi(lua_State *L);
 void luaP_pushcursor (lua_State *L, Portal cursor);
+void luaP_pushrecord(lua_State *L, Datum record);
 Portal luaP_tocursor (lua_State *L, int pos);
 
 /* =========================================================================

--- a/pllua_pgfunc.c
+++ b/pllua_pgfunc.c
@@ -13,13 +13,10 @@ only_internal = true --false,
 throwable = true --false
 --[[ throwable makes PG_TRY PG_CATCH for non internal functions]]
 
-]]
-
 }
 
 Note:
 Set returning functions are not supported.
-In/Out functions are not supported.
 No checks if function is strict.
 
  */
@@ -39,321 +36,336 @@ No checks if function is strict.
 
 static const char pg_func_type_name[] = "pg_func";
 
-static Oid find_lang_oids(const char* lang){
-    HeapTuple		tuple;
-    tuple = SearchSysCache(LANGNAME, CStringGetDatum(lang), 0, 0, 0);
-    if (HeapTupleIsValid(tuple))
-    {
-        Oid langtupoid = HeapTupleGetOid(tuple);
-        ReleaseSysCache(tuple);
-        return langtupoid;
-    }
-    return 0;
+static Oid
+find_lang_oids(const char* lang)
+{
+	HeapTuple tuple;
+	tuple = SearchSysCache(LANGNAME, CStringGetDatum(lang), 0, 0, 0);
+	if (HeapTupleIsValid(tuple))
+	{
+		Oid langtupoid = HeapTupleGetOid(tuple);
+		ReleaseSysCache(tuple);
+		return langtupoid;
+	}
+	return 0;
 }
 
 static Oid pllua_oid = 0;
 static Oid plluau_oid = 0;
-static Oid get_pllua_oid(){
-    if (pllua_oid !=0)
-        return pllua_oid;
-    return find_lang_oids("pllua");
+
+static Oid
+get_pllua_oid()
+{
+	if (pllua_oid !=0)
+		return pllua_oid;
+	return find_lang_oids("pllua");
 }
 
-static Oid get_plluau_oid(){
-    if (plluau_oid !=0)
-        return plluau_oid;
-    return find_lang_oids("plluau");
+static Oid
+get_plluau_oid()
+{
+	if (plluau_oid !=0)
+		return plluau_oid;
+	return find_lang_oids("plluau");
 }
 
 typedef struct{
-    bool only_internal;
-    bool throwable;
+	bool only_internal;
+	bool throwable;
 } Pgfunc_options;
 
 typedef struct{
-    Oid         funcid;
-    int			numargs;
-    Oid		   *argtypes;
-    char	  **argnames;
-    char	   *argmodes;
-    lua_CFunction  callfunc;
-    Oid         prorettype;
+	Oid funcid;
+	int numargs;
+	Oid *argtypes;
+	lua_CFunction callfunc;
+	Oid prorettype;
 
-    FmgrInfo	fi;
-    Pgfunc_options options;
+	FmgrInfo fi;
+	Pgfunc_options options;
 } PgFuncInfo, Lua_pgfunc;
 
-#define freeandnil(p)    do{ if (p){\
-    pfree(p);\
-    p = NULL;\
-    }}while(0)
+#define freeandnil(p) do{ if (p){\
+	pfree(p);\
+	p = NULL;\
+	}}while(0)
 
-static void clean_pgfuncinfo(Lua_pgfunc *data){
-    freeandnil (data->argtypes);
-    freeandnil (data->argnames);
-    freeandnil (data->argmodes);
+static void
+clean_pgfuncinfo(Lua_pgfunc *data)
+{
+	freeandnil (data->argtypes);
 }
 
-static MemoryContext get_tmpcontext(){
-    MemoryContext mc;
-    mc = AllocSetContextCreate(TopMemoryContext,
-                                                     "pgfunc temporary context",
-                                                     ALLOCSET_DEFAULT_MINSIZE,
-                                                     ALLOCSET_DEFAULT_INITSIZE,
-                                                     ALLOCSET_DEFAULT_MAXSIZE);
-    return mc;
+static MemoryContext
+get_tmpcontext()
+{
+	MemoryContext mc;
+	mc = AllocSetContextCreate(TopMemoryContext,
+				   "pgfunc temporary context",
+				   ALLOCSET_DEFAULT_MINSIZE,
+				   ALLOCSET_DEFAULT_INITSIZE,
+				   ALLOCSET_DEFAULT_MAXSIZE);
+	return mc;
 }
 
 static MemoryContext tmpcontext;
 static int tmpcontext_usage = 0;
 
-static int pg_callable_func(lua_State *L)
+static int
+pg_callable_func(lua_State *L)
 {
-    MemoryContext m;
-    int i;
-    FunctionCallInfoData fcinfo;
-    Lua_pgfunc *fi = (Lua_pgfunc *) lua_touserdata(L, lua_upvalueindex(1));
-    InitFunctionCallInfoData(fcinfo, &fi->fi, fi->numargs, InvalidOid, NULL, NULL);
+	MemoryContext m;
+	int i;
+	FunctionCallInfoData fcinfo;
+	Lua_pgfunc *fi;
 
-    if(tmpcontext_usage> RESET_CONTEXT_AFTER ){
-        MemoryContextReset(tmpcontext);
-        tmpcontext_usage = 0;
-    }
-    ++tmpcontext_usage;
+	fi = (Lua_pgfunc *) lua_touserdata(L, lua_upvalueindex(1));
 
-    m = MemoryContextSwitchTo(tmpcontext);
+	InitFunctionCallInfoData(fcinfo, &fi->fi, fi->numargs, InvalidOid, NULL, NULL);
 
-    for (i=0; i<fi->numargs; ++i){
-        fcinfo.arg[i] = luaP_todatum(L, fi->argtypes[i], 0, &fcinfo.argnull[i], i+1);
-    }
+	if(tmpcontext_usage> RESET_CONTEXT_AFTER ){
+		MemoryContextReset(tmpcontext);
+		tmpcontext_usage = 0;
+	}
+	++tmpcontext_usage;
 
-    if(!fi->options.only_internal && fi->options.throwable){\
-        SPI_push();
-        PG_TRY();
-        {
-            Datum d = FunctionCallInvoke(&fcinfo);
-            MemoryContextSwitchTo(m);
-            luaP_pushdatum(L, d, fi->prorettype);
-            SPI_pop();
-        }
-        PG_CATCH();
-        {
-            lua_pop(L, lua_gettop(L));
-            push_spi_error(L, m); /*context switch to m inside push_spi_error*/
-            SPI_pop();
-            return lua_error(L);
-        }PG_END_TRY();
-    }else{
-        Datum d = FunctionCallInvoke(&fcinfo);
-        MemoryContextSwitchTo(m);
-        luaP_pushdatum(L, d, fi->prorettype);
-    }
+	m = MemoryContextSwitchTo(tmpcontext);
 
-    return 1;
+	for (i=0; i<fi->numargs; ++i){
+		fcinfo.arg[i] = luaP_todatum(L, fi->argtypes[i], 0, &fcinfo.argnull[i], i+1);
+	}
+
+	if(!fi->options.only_internal && fi->options.throwable){
+		SPI_push();
+		PG_TRY();
+		{
+			Datum d = FunctionCallInvoke(&fcinfo);
+			MemoryContextSwitchTo(m);
+			luaP_pushdatum(L, d, fi->prorettype);
+			SPI_pop();
+		}
+		PG_CATCH();
+		{
+			lua_pop(L, lua_gettop(L));
+			push_spi_error(L, m); /*context switch to m inside push_spi_error*/
+			SPI_pop();
+			return lua_error(L);
+		}PG_END_TRY();
+	}else{
+		Datum d = FunctionCallInvoke(&fcinfo);
+		MemoryContextSwitchTo(m);
+		luaP_pushdatum(L, d, fi->prorettype);
+	}
+
+	return 1;
 }
 
-static void parse_options(lua_State *L, Pgfunc_options *opt){
-    lua_pushnil(L);
-    while (lua_next(L, -2) != 0) {
-        if (lua_type(L, -2) == LUA_TSTRING){
-            const char *key = lua_tostring(L, -2);
+static void
+parse_options(lua_State *L, Pgfunc_options *opt){
+	lua_pushnil(L);
+	while (lua_next(L, -2) != 0) {
+		if (lua_type(L, -2) == LUA_TSTRING){
+			const char *key = lua_tostring(L, -2);
 
-            if (strcmp(key, "only_internal") == 0){
-                opt->only_internal =  lua_toboolean(L, -1);
-            } else if (strcmp(key, "throwable") == 0){
-                opt->throwable =  lua_toboolean(L, -1);
-            } else {
-                luaL_error(L, "pgfunc unknown option \"%s\"", key);
-            }
+			if (strcmp(key, "only_internal") == 0){
+				opt->only_internal =  lua_toboolean(L, -1);
+			} else if (strcmp(key, "throwable") == 0){
+				opt->throwable =  lua_toboolean(L, -1);
+			} else {
+				luaL_error(L, "pgfunc unknown option \"%s\"", key);
+			}
 
-        }
-        lua_pop(L, 1);
-    }
+		}
+		lua_pop(L, 1);
+	}
 }
 
-int get_pgfunc(lua_State *L)
+int
+get_pgfunc(lua_State *L)
 {
-    Lua_pgfunc *lf;
-    Pgfunc_options opt;
-    MemoryContext mcxt;
-    MemoryContext m;
-    const char* reg_name = NULL;
-    HeapTuple	proctup;
+	Lua_pgfunc *lf;
+	Pgfunc_options opt;
+	MemoryContext m;
+	const char* reg_name = NULL;
+	HeapTuple proctup;
+	Form_pg_proc proc;
+	int luasrc = 0;
+	Oid funcid = 0;
 
-    Form_pg_proc proc;
-    const char* reg_error = NULL;
-    int i;
-    int luasrc = 0;
-    Oid funcid = 0;
+	BEGINLUA;
 
-    BEGINLUA;
+	opt.only_internal = true;
+	opt.throwable = true;
 
-    opt.only_internal = true;
-    opt.throwable = true;
+	if (lua_gettop(L) == 2){
+		luaL_checktype(L, 2, LUA_TTABLE);
+		parse_options(L, &opt);
+	}else if (lua_gettop(L) != 1){
+		return luaL_error(L, "pgfunc(text): wrong arguments");
+	}
+	if(lua_type(L, 1) == LUA_TSTRING){
+		reg_name = luaL_checkstring(L, 1);
+		m = MemoryContextSwitchTo(tmpcontext);
+		PG_TRY();
+		{
+			funcid = DatumGetObjectId(DirectFunctionCall1(regprocedurein, CStringGetDatum(reg_name)));
+		}
+		PG_CATCH();{}
+		PG_END_TRY();
+		MemoryContextSwitchTo(m);
+		MemoryContextReset(tmpcontext);
+	}else if (lua_type(L, 1) == LUA_TNUMBER){
+		funcid = luaL_checkinteger(L, 1);
+	}
 
-    if (lua_gettop(L) == 2){
-        luaL_checktype(L, 2, LUA_TTABLE);
-        parse_options(L, &opt);
-    }else if (lua_gettop(L) != 1){
-        return luaL_error(L, "pgfunc(text): wrong arguments");
-    }
-    if(lua_type(L, 1) == LUA_TSTRING){
-        reg_name = luaL_checkstring(L, 1);
+	if (!OidIsValid(funcid)){
+		if (reg_name)
+			return luaL_error(L,"failed to register %s", reg_name);
+		return luaL_error(L,"failed to register function with oid %d", funcid);
+	}
 
-        PG_TRY();
-        {
-            funcid = DatumGetObjectId(DirectFunctionCall1(regprocedurein, CStringGetDatum(reg_name)));
-        }
-        PG_CATCH();{}
-        PG_END_TRY();
-    }else if (lua_type(L, 1) == LUA_TNUMBER){
-        funcid = luaL_checkinteger(L, 1);
-    }
+	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
+	if (!HeapTupleIsValid(proctup)){
+		return luaL_error(L,"cache lookup failed for function %d", funcid);
+	}
 
-    if (!OidIsValid(funcid)){
-        if (reg_name)
-            return luaL_error(L,"failed to register %s", reg_name);
-        return luaL_error(L,"failed to register function with oid %d", funcid);
-    }
+	proc = (Form_pg_proc) GETSTRUCT(proctup);
 
-    proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
-    if (!HeapTupleIsValid(proctup)){
-        return luaL_error(L,"cache lookup failed for function %d", funcid);
-    }
-
-    proc = (Form_pg_proc) GETSTRUCT(proctup);
-
-    luasrc = ((proc->prolang == get_pllua_oid())
-              || (proc->prolang == get_plluau_oid()));
-    if ( opt.only_internal
-            &&(proc->prolang != INTERNALlanguageId)
-            &&(!luasrc) ){
-        ReleaseSysCache(proctup);
-        return luaL_error(L, "supported only SQL/internal functions");
-    }
-
-    lf = (Lua_pgfunc *)lua_newuserdata(L, sizeof(Lua_pgfunc));
-
-    /*make it g/collected*/
-    luaP_getfield(L, pg_func_type_name);
-    lua_setmetatable(L, -2);
+	luasrc = ((proc->prolang == get_pllua_oid())
+		  || (proc->prolang == get_plluau_oid()));
+	if ( opt.only_internal
+			&&(proc->prolang != INTERNALlanguageId)
+			&&(!luasrc) ){
+		ReleaseSysCache(proctup);
+		return luaL_error(L, "supported only SQL/internal functions");
+	}
 
 
-    lf->prorettype = proc->prorettype;
-    lf->funcid = funcid;
-    lf->options = opt;
+	lf = (Lua_pgfunc *)lua_newuserdata(L, sizeof(Lua_pgfunc));
 
-    mcxt = get_common_ctx();
-    m  = MemoryContextSwitchTo(mcxt);
-
-    lf->numargs = get_func_arg_info(proctup,
-                                    &lf->argtypes, &lf->argnames, &lf->argmodes);
-
-    m  = MemoryContextSwitchTo(m);
-
-    if (luasrc){
-        bool isnull;
-        text *t;
-        const char *s;
-        luaL_Buffer b;
-        int pcall_result;
-        Datum prosrc;
-
-        if((lf->numargs != 1)
-                || (lf->argtypes[0] != INTERNALOID)
-                || (lf->prorettype != INTERNALOID)){
-            luaL_error(L, "pgfunc accepts only 'internal' pllua/u functions with internal argument");
-        }
-
-        prosrc = SysCacheGetAttr(PROCOID, proctup, Anum_pg_proc_prosrc, &isnull);
-        if (isnull) elog(ERROR, "[pgfunc]: null lua prosrc");
-        luaL_buffinit(L, &b);
-
-        luaL_addstring(&b,"do ");
-        t = DatumGetTextP(prosrc);
-        luaL_addlstring(&b, VARDATA(t), VARSIZE(t) - VARHDRSZ);
-        luaL_addstring(&b, " end");
-        luaL_pushresult(&b);
-        s = lua_tostring(L, -1);
-
-        ReleaseSysCache(proctup);
-        clean_pgfuncinfo(lf);
-
-        if (luaL_loadbuffer(L, s, strlen(s), "pgfunc chunk"))
-                  luaL_error(L, "compile");
-
-        lua_remove(L, -2); /*delete source element*/
-
-        pcall_result = lua_pcall(L, 0, 1, 0);
-        lua_remove(L, -2); /*delete chunk*/
-        if(pcall_result == 0){
-            ENDLUAV(1);
-            return 1;
-        }
-
-        if( pcall_result == LUA_ERRRUN)
-            luaL_error(L,"%s %s","Runtime error:",lua_tostring(L, -1));
-        else if(pcall_result == LUA_ERRMEM)
-            luaL_error(L,"%s %s","Memory error:",lua_tostring(L, -1));
-        else if(pcall_result == LUA_ERRERR)
-            luaL_error(L,"%s %s","Error:",lua_tostring(L, -1));
-
-        return luaL_error(L, "pgfunc unknown error");
-    }
+	/*make it g/collected*/
+	luaP_getfield(L, pg_func_type_name);
+	lua_setmetatable(L, -2);
 
 
-    if (lf->numargs >9){
-        reg_error = "not supported function with more than 9 arguments";
-    }else {
-        for (i = 0; i < lf->numargs; i++){
-            char		argmode = lf->argmodes ? lf->argmodes[i] : PROARGMODE_IN;
-            if (argmode != PROARGMODE_IN){
-                reg_error = "only input parameters supported";
-                break;
-            }
-        }
-    }
-    if (reg_error){
-        ReleaseSysCache(proctup);
-        clean_pgfuncinfo(lf);
-        return luaL_error(L, "pgfunc error: %s",reg_error);
-    }
+	lf->prorettype = proc->prorettype;
+	lf->funcid = funcid;
+	lf->options = opt;
 
-    fmgr_info(funcid, &lf->fi);
+	{
+		Oid *argtypes;
+		char **argnames;
+		char *argmodes;
+		int argc;
+		MemoryContext cur = CurrentMemoryContext;
 
-    lua_pushcclosure(L, pg_callable_func, 1);
+		MemoryContextSwitchTo(tmpcontext);
 
-    ReleaseSysCache(proctup);
+		argc = get_func_arg_info(proctup,
+					 &argtypes, &argnames, &argmodes);
 
-    ENDLUAV(1);
-    return 1;
+		MemoryContextSwitchTo(get_common_ctx());
+
+		lf->numargs = argc;
+		lf->argtypes = (Oid*)palloc(argc * sizeof(Oid));
+		memcpy(lf->argtypes, argtypes, argc * sizeof(Oid));
+		MemoryContextSwitchTo(cur);
+		MemoryContextReset(tmpcontext);
+	}
+
+	if (luasrc){
+		bool isnull;
+		text *t;
+		const char *s;
+		luaL_Buffer b;
+		int pcall_result;
+		Datum prosrc;
+
+		if((lf->numargs != 1)
+				|| (lf->argtypes[0] != INTERNALOID)
+				|| (lf->prorettype != INTERNALOID)){
+			luaL_error(L, "pgfunc accepts only 'internal' pllua/u functions with internal argument");
+		}
+
+		prosrc = SysCacheGetAttr(PROCOID, proctup, Anum_pg_proc_prosrc, &isnull);
+		if (isnull) elog(ERROR, "[pgfunc]: null lua prosrc");
+		luaL_buffinit(L, &b);
+
+		luaL_addstring(&b,"do ");
+		t = DatumGetTextP(prosrc);
+		luaL_addlstring(&b, VARDATA(t), VARSIZE(t) - VARHDRSZ);
+		luaL_addstring(&b, " end");
+		luaL_pushresult(&b);
+		s = lua_tostring(L, -1);
+
+		ReleaseSysCache(proctup);
+		clean_pgfuncinfo(lf);
+
+		if (luaL_loadbuffer(L, s, strlen(s), "pgfunc chunk"))
+			luaL_error(L, "compile");
+
+		lua_remove(L, -2); /*delete source element*/
+
+		pcall_result = lua_pcall(L, 0, 1, 0);
+		lua_remove(L, -2); /*delete chunk*/
+		if(pcall_result == 0){
+			ENDLUAV(1);
+			return 1;
+		}
+
+		if( pcall_result == LUA_ERRRUN)
+			luaL_error(L,"%s %s","Runtime error:",lua_tostring(L, -1));
+		else if(pcall_result == LUA_ERRMEM)
+			luaL_error(L,"%s %s","Memory error:",lua_tostring(L, -1));
+		else if(pcall_result == LUA_ERRERR)
+			luaL_error(L,"%s %s","Error:",lua_tostring(L, -1));
+
+		return luaL_error(L, "pgfunc unknown error");
+	}
+
+
+	fmgr_info(funcid, &lf->fi);
+
+	lua_pushcclosure(L, pg_callable_func, 1);
+
+	ReleaseSysCache(proctup);
+
+	ENDLUAV(1);
+	return 1;
 }
 
-static void __newmetatable (lua_State *L, const char *tname)
+static void
+__newmetatable (lua_State *L, const char *tname)
 {
-    lua_newtable(L);
-    lua_pushlightuserdata(L, (void *) tname);
-    lua_pushvalue(L, -2);
-    lua_rawset(L, LUA_REGISTRYINDEX);
+	lua_newtable(L);
+	lua_pushlightuserdata(L, (void *) tname);
+	lua_pushvalue(L, -2);
+	lua_rawset(L, LUA_REGISTRYINDEX);
 }
 
-static int gc_pg_func(lua_State *L)
+static int
+gc_pg_func(lua_State *L)
 {
-    Lua_pgfunc *lf = lua_touserdata(L, 1);
-    clean_pgfuncinfo(lf);
-    return 0;
+	Lua_pgfunc *lf = lua_touserdata(L, 1);
+	clean_pgfuncinfo(lf);
+	return 0;
 }
 
-static luaL_Reg regs[] =
-{
-    {"__gc", gc_pg_func},
-    { NULL, NULL }
+static luaL_Reg regs[] = {
+	{"__gc", gc_pg_func},
+	{ NULL, NULL }
 };
 
-void register_funcinfo_mt(lua_State *L)
+static bool cxt_initialized = false;
+
+void
+register_funcinfo_mt(lua_State *L)
 {
-    __newmetatable(L, pg_func_type_name);
-    luaP_register(L, regs);
-    lua_pop(L, 1);
-    tmpcontext = get_tmpcontext();
+	__newmetatable(L, pg_func_type_name);
+	luaP_register(L, regs);
+	lua_pop(L, 1);
+	if (!cxt_initialized){
+		tmpcontext = get_tmpcontext();
+		cxt_initialized = true;
+	}
 }

--- a/plluaapi.c
+++ b/plluaapi.c
@@ -464,12 +464,25 @@ static int luaP_fromstring (lua_State *L) {
   return 1;
 }
 
+#ifdef PLLUA_DEBUG
+static int
+luaP_memstat(lua_State *L)
+{
+	(void)L;
+	MemoryContextStats(TopMemoryContext);
+	return 0;
+}
+#endif
+
 static const luaL_Reg luaP_funcs[] = {
     {"assert", luaB_assert},
     {"error", luaB_error},
     {"fromstring", luaP_fromstring},
     {"info", luaP_info},
     {"log", luaP_log},
+#ifdef PLLUA_DEBUG
+    {"memstat", luaP_memstat},
+#endif
     {"notice", luaP_notice},
     {"pcall", subt_luaB_pcall},
     {"pgfunc", get_pgfunc},
@@ -872,6 +885,9 @@ void luaP_pushdatum (lua_State *L, Datum dat, Oid type) {
       else lua_pushnil(L);
       break;
     }
+    case RECORDOID:
+      luaP_pushrecord(L, dat);
+      break;
     default: {
       luaP_Typeinfo *ti;
       ti = luaP_gettypeinfo(L, type);

--- a/sql/pgfunctest.sql
+++ b/sql/pgfunctest.sql
@@ -64,3 +64,32 @@ do $$
 local f = pgfunc('pg_temp.no_throw()',{only_internal=false, throwable=false})
 print(f())
 $$ language pllua;
+CREATE or replace FUNCTION pg_temp.arg_count(a1 integer,a2 integer,a3 integer,a4 integer,a5 integer
+,a6 integer,a7 integer,a8 integer,a9 integer,a10 integer
+,a11 integer,a12 integer,a13 integer,a14 integer,a15 integer ) returns integer AS
+$$
+begin
+return a1+a2+a3+a4+a5+a6+a7+a8+a9+a10+a11+a12+a13+a14+a15;
+end
+$$
+LANGUAGE plpgsql;
+do $$
+local f = pgfunc([[pg_temp.arg_count(integer, integer, integer, integer, integer,
+ integer, integer, integer, integer, integer, 
+ integer, integer, integer, integer, integer ) ]],{only_internal=false});
+print(f(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15))
+$$ language pllua;
+CREATE or replace FUNCTION pg_temp.inoutf(a integer, INOUT b text, INOUT c text)  AS
+$$
+begin
+c = a||'c:'||c;
+b = 'b:'||b;
+end
+$$
+LANGUAGE plpgsql;
+do $$
+local f = pgfunc('pg_temp.inoutf(integer,text,text)',{only_internal=false});
+local r = f(5, 'ABC', 'd')
+print(r.b)
+print(r.c)
+$$ language pllua

--- a/sql/plluatest.sql
+++ b/sql/plluatest.sql
@@ -318,6 +318,22 @@ $$ LANGUAGE pllua;
 
 select quote_nullable(pg_temp.srf());
 
+CREATE or replace FUNCTION pg_temp.inoutf(a integer, INOUT b text, INOUT c text)  AS
+$$
+begin
+c = a||'c:'||c;
+b = 'b:'||b;
+end
+$$
+LANGUAGE plpgsql;
+
+do $$
+local a = server.execute("SELECT pg_temp.inoutf(5, 'ABC', 'd') as val ");
+local r = a[1].val
+print(r.b)
+print(r.c)
+$$ language pllua;
+
 -- body reload
 SELECT hello('PostgreSQL');
 CREATE OR REPLACE FUNCTION hello(name text)


### PR DESCRIPTION
- added support in/out functions for pgfunc
- added luaP_pushrecord, and so possible to select from in/out functions, example:
  CREATE or replace FUNCTION pg_temp.inoutf(a integer, INOUT b text, INOUT c text)  AS
  $$
  ....
  $$
  LANGUAGE plpgsql;
  do $$
  local a = server.execute("SELECT pg_temp.inoutf(5, 'ABC', 'd') as val ");
  local r = a[1].val
  print(r.b)
  print(r.c)
  $$ language pllua;
- added tests for IN/OUT function queries/calls
- fixed leaks for intensive pgfunc lookups
- changed tabs and spaces for pgfunc.c
- Update .travis.yml for 9.5
